### PR TITLE
Adding 'counters' field to profile_fields function

### DIFF
--- a/R/users.R
+++ b/R/users.R
@@ -815,7 +815,7 @@ profile_fields <- function(fields = '') {
                   'can_see_audio', 'can_write_private_message', 'can_send_friend_request',
                   'is_favorite', 'is_hidden_from_feed', 'timezone', 'screen_name', 'maiden_name',
                   'crop_photo', 'is_friend', 'friend_status', 'career', 'military', 'blacklisted',
-                  'blacklisted_by_me')
+                  'blacklisted_by_me', 'counters')
 
   if (fields == '')
     return(fields)


### PR DESCRIPTION
VK api allows to do request with 'counters' field, which is currently missing.
Response of such request can look like this:

{
"response": [{
"id": 9999,
"first_name": "test",
"last_name": "test",
"is_closed": false,
"can_access_closed": true,
"counters": {
  "albums": 18,
  "videos": 206,
  "audios": 380,
  "notes": 107,
  "photos": 5444,
  "gifts": 99,
  "friends": 5304,
  "online_friends": 744,
  "mutual_friends": 0,
  "user_photos": 1984,
  "followers": 1307,
  "subscriptions": 0,
  "pages": 74
}
}]
}